### PR TITLE
Potential fix for code scanning alert no. 43: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: "Semantic PRs"
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/43](https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/43)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimal permissions required for the job. The best practice is to set this at the workflow level (top-level, after `name:` and before `on:`), so all jobs inherit these permissions unless overridden. For the `amannn/action-semantic-pull-request` action, the minimal required permissions are typically `contents: read` (to read repository contents) and `pull-requests: write` (to update PR status or comments). Therefore, add:

```yaml
permissions:
  contents: read
  pull-requests: write
```

immediately after the `name:` line and before the `on:` block in `.github/workflows/semantic-pr.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
