### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Run top issues action


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/20](https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/20)

To fix the problem, add a `permissions` block to the job (or at the workflow root) specifying the minimum required permissions. Since the action is labeling issues and possibly reading repository contents, the minimal permissions should be `contents: read` and `issues: write`. This block should be added under the `ShowAndLabelTopIssues` job (line 14), before the `runs-on` key. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
