### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Rust
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/19](https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/19)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the minimal required permissions for the GITHUB_TOKEN. Since the workflow only checks out code, builds, and runs tests, it only needs read access to repository contents. The best way to implement this is to add the following block at the top level of the workflow file (just after the `name:` and before `on:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
