### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@
    push:
      branches:
        - develop
+ permissions:
+   contents: write
+   pull-requests: write
  jobs:
    release-please:
      runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/17](https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/17)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply only to the specific job). The minimal permissions required for the `release-please-action` are typically `contents: write` and `pull-requests: write`, as it needs to create releases and open/update pull requests. You should add the following block above the `jobs:` key in `.github/workflows/release-please.yml`:

```yaml
permissions:
  contents: write
  pull-requests: write
```

This change restricts the GITHUB_TOKEN to only the permissions needed for this workflow, following the principle of least privilege. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
