### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: '💥 Auto-Label Merge Conflicts on PRs'
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/16](https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/16)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions granted to the `GITHUB_TOKEN`. The block should be placed at the workflow root (top-level, before `jobs:`) to apply to all jobs unless overridden. For this workflow, which labels pull requests with merge conflicts, the minimal required permissions are `contents: read` (to read repository contents) and `pull-requests: write` (to label PRs). Edit `.github/workflows/merge-conflict-autolabel.yml` to insert the following block after the `name` and before `on:`:

```yaml
permissions:
  contents: read
  pull-requests: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
