### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -1,5 +1,10 @@
 name: Add bugs to the relevant GitHub Projects
 
+permissions:
+  issues: write
+  projects: write
+  contents: read
+
 on:
   issues:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/14](https://github.com/openfoodfacts/openfoodfacts-rust/security/code-scanning/14)

To fix the problem, add a `permissions` block to the workflow file to restrict the permissions granted to the `GITHUB_TOKEN`. The block should be placed at the top level of the workflow (before `jobs:`) to apply to all jobs, unless a job-specific override is needed. Since the workflow interacts with issues and projects, the minimal required permissions are likely `issues: write` and `projects: write`. If the workflow only needs to read repository contents, you can also set `contents: read`. The change should be made at the top of the file, after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
