### PR TITLE
chore: Update reqwest to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = {version = "0.12", features = ["blocking", "json"]}
+reqwest = { version = "0.13.1", features = ["blocking", "json", "query"] }
 # From reqwest
 base64 = "0.22"
 url = "2.2"
 serde = "1.0"
 serde_json = "1.0.73"
 serde_urlencoded = "0.7"
-
-


### PR DESCRIPTION
This allows using rustls instead of forcing a hard dependency on native tls (openssl)

- closes #66
- closes #65